### PR TITLE
Add executionRoleArn  in CONDITIONAL_OPTIONS

### DIFF
--- a/ecs-deploy
+++ b/ecs-deploy
@@ -313,7 +313,7 @@ function createNewTaskDefJson() {
 
     # Some options in task definition should only be included in new definition if present in
     # current definition. If found in current definition, append to JQ filter.
-    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints)
+    CONDITIONAL_OPTIONS=(networkMode taskRoleArn placementConstraints executionRoleArn)
     for i in "${CONDITIONAL_OPTIONS[@]}"; do
       re=".*${i}.*"
       if [[ "$DEF" =~ $re ]]; then


### PR DESCRIPTION
To fix error: An error occurred (ClientException) when calling the RegisterTaskDefinition operation: When you are specifying container secrets, you must also specify a value for 'executionRoleArn'.